### PR TITLE
feature/past stat graphs

### DIFF
--- a/app/Filament/Resources/CardResource/Widgets/SpentPayingSaving.php
+++ b/app/Filament/Resources/CardResource/Widgets/SpentPayingSaving.php
@@ -9,7 +9,6 @@ use App\Models\Collections\StateDumpCollection as SDC;
 use App\Models\Payment;
 use App\Models\StateDump;
 use App\Models\User;
-use Carbon\Carbon;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
 use Illuminate\Database\Eloquent\Builder;
@@ -145,17 +144,5 @@ class SpentPayingSaving extends BaseWidget
             + $query->sum('pending')
             - $query->sum('interest_free_balance')
             + $query->sum('interest_free_balance_payment');
-    }
-
-    private static function fixforWeekends(int $day): Carbon
-    {
-        $exact = now()->setDay($day);
-
-        return $exact->isSunday()
-            ? $exact->subDays(2)
-            : ($exact->isSaturday()
-                ? $exact->subDay()
-                : $exact
-            );
     }
 }

--- a/app/Filament/Widgets/CardWidget.php
+++ b/app/Filament/Widgets/CardWidget.php
@@ -39,12 +39,15 @@ class CardWidget extends BaseWidget
                     }),
                 Tables\Columns\TextInputColumn::make('balance')
                     ->rules(['numeric'])
+                    ->updateStateUsing(fn ($record, $state) => $record->update(['balance' => is_null($state) ? 0 : $state]))
                     ->summarize(Sum::make()->money()->label('')),
                 Tables\Columns\TextInputColumn::make('pending')
                     ->rules(['numeric'])
+                    ->updateStateUsing(fn ($record, $state) => $record->update(['pending' => is_null($state) ? 0 : $state]))
                     ->summarize(Sum::make()->money()->label('')),
                 Tables\Columns\TextInputColumn::make('interest_saving_balance')
                     ->rules(['numeric'])
+                    ->updateStateUsing(fn ($record, $state) => $record->update(['interest_saving_balance' => is_null($state) ? 0 : $state]))
                     ->label('ISB')
                     ->summarize([
                         Sum::make()->money()->label('Total'),
@@ -52,10 +55,11 @@ class CardWidget extends BaseWidget
                             ->query(fn (Builder $query) => $query->where('due_date', '>=', now()->day))
                             ->money()->label('Unpaid'),
                     ]),
-                Tables\Columns\TextInputColumn::make('interest_free_balance')
+                Tables\Columns\TextInputColumn::make('points_balance')
                     ->rules(['numeric'])
-                    ->label('0% Bal')
-                    ->summarize(Sum::make()->money()->label('')),
+                    ->updateStateUsing(fn ($record, $state) => $record->update(['points_balance' => is_null($state) ? 0 : $state]))
+                    ->label('Pts Bal')
+                    ->summarize(Sum::make()->numeric()->label('')),
             ]);
     }
 }


### PR DESCRIPTION
- **feature : This Month Spends widget,**
- **bugfix : woops,**
- **bugfix : order,**
- **feature : Satisfied SUB indicators,**
- **bugfix : bools,**
- **feature : New Graphs! New Stats! Color! Light! Sound! wait, no sound. But all the rest of that stuff!,**
- **feature : Card benefits, points program tracking, composer updates,**
- **feature : Points program selector,**
- **bugfix : FORGOT AEROPLAN OH GOD OH FUCK OH GOD,**
- **feature : Cards have Cardholders,**
- **feature : Annual fee,**
- **feature : due dates on cards,**
- **bugfix : moar,**
- **bugfix : absolute diffs,**
- **bugfix : This month planned unspent included in calc,**
- **feature : Rebalanced math and dash table,**
- **bugfix : deleting spends deletes payments,**
- **feature : Statement Date and jobs that use it,**
- **feature : Widget cleanup and todayline,**
- **feature : move to DailyUpkeep,**
- **feature : Highlighting due cards,**
- **feature : Redo dash stats,**
- **chore : rm unused,**
- **feature : smooth out empty fields in dashboard,**
