### PR TITLE
Harden production memory and block common nginx probes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,10 @@ MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 XDEBUG=false
 XDEBUG_PORT=0000
 
+# Production: set TELESCOPE_ENABLED=false if you rely on Nightwatch only.
 TELESCOPE_ENABLED=true
+
+# Queue workers (production Horizon supervisor cap). ~128 MB per worker.
+HORIZON_MAX_PROCESSES=4
 
 SIMPLE_FIN_URL=

--- a/app/Providers/TelescopeServiceProvider.php
+++ b/app/Providers/TelescopeServiceProvider.php
@@ -21,13 +21,15 @@ class TelescopeServiceProvider extends TelescopeApplicationServiceProvider
         $isLocal = $this->app->environment('local');
 
         Telescope::filter(function (IncomingEntry $entry) use ($isLocal) {
-            return $isLocal ||
-                   $entry->isRequest() ||
-                   $entry->isReportableException() ||
-                   $entry->isFailedRequest() ||
-                   $entry->isFailedJob() ||
-                   $entry->isScheduledTask() ||
-                   $entry->hasMonitoredTag();
+            if ($isLocal) {
+                return true;
+            }
+
+            return $entry->isReportableException()
+                || $entry->isFailedRequest()
+                || $entry->isFailedJob()
+                || $entry->isScheduledTask()
+                || $entry->hasMonitoredTag();
         });
     }
 

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -215,7 +215,7 @@ return [
     'environments' => [
         'production' => [
             'supervisor-1' => [
-                'maxProcesses' => 10,
+                'maxProcesses' => (int) env('HORIZON_MAX_PROCESSES', 4),
                 'balanceMaxShift' => 1,
                 'balanceCooldown' => 3,
             ],

--- a/deploy/nginx/rate-limit-http.conf
+++ b/deploy/nginx/rate-limit-http.conf
@@ -1,0 +1,9 @@
+# Install once on the Forge server (http context — not inside server {}):
+#
+#   sudo cp deploy/nginx/rate-limit-http.conf /etc/nginx/conf.d/rate-limit-erikgratz.conf
+#   sudo nginx -t && sudo systemctl reload nginx
+#
+# Then merge deploy/nginx/site-snippet.conf into the site's Nginx config in Forge.
+
+limit_req_zone $binary_remote_addr zone=erikgratz_web:10m rate=10r/s;
+limit_req_status 429;

--- a/deploy/nginx/site-snippet.conf
+++ b/deploy/nginx/site-snippet.conf
@@ -1,0 +1,28 @@
+# Merge into Forge: site → Meta → Edit Nginx Configuration.
+# Place probe blocks and rate limits BEFORE the existing "location /" block.
+# Keep Forge's existing location = /index.php and fastcgi blocks unchanged.
+
+# Rate limit normal page traffic (zone defined in conf.d/rate-limit-erikgratz.conf)
+limit_req zone=erikgratz_web burst=40 nodelay;
+
+# Drop obvious scanner targets (Laravel only uses public/index.php)
+location = /.env {
+    return 444;
+}
+
+location ~* ^/(\.git|\.svn|\.hg|\.env) {
+    return 444;
+}
+
+location ~* ^/(wp-admin|wp-content|wp-includes|wp-login\.php|xmlrpc\.php|cgi-bin) {
+    return 444;
+}
+
+location ~* ^/(phpmyadmin|pma|mysql|administrator|\.well-known/security\.txt) {
+    return 444;
+}
+
+# Any *.php except front controller — blocks shell probes without booting PHP
+location ~* ^(?!/index\.php$).+\.php$ {
+    return 444;
+}

--- a/deploy/php-fpm-www.pool.snippet
+++ b/deploy/php-fpm-www.pool.snippet
@@ -1,0 +1,14 @@
+; Paste into Forge: Server → PHP → FPM (pool www), or merge into
+; /etc/php/8.4/fpm/pool.d/www.conf then: sudo systemctl reload php8.4-fpm
+;
+; Sizing pm.max_children (example for a 2 GB droplet):
+;   Reserve ~500 MB OS/MySQL/Redis/Nginx, ~512 MB for Horizon (4 × 128 MB),
+;   ~400 MB left for FPM → 400 / 120 ≈ 3–5 children. Adjust for your RAM.
+
+pm.max_requests = 500
+request_terminate_timeout = 60s
+
+; Forge UI equivalents (if you prefer the dashboard):
+;   Max Requests = 500
+;   Request Terminate Timeout = 60
+;   Max Children = (see calculation above; start with 5 on 2 GB, 8–10 on 4 GB)

--- a/tests/Feature/Providers/TelescopeServiceProviderTest.php
+++ b/tests/Feature/Providers/TelescopeServiceProviderTest.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Tests\Feature\Providers;
+
+use App\Models\User;
+use App\Providers\TelescopeServiceProvider;
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Support\Facades\Gate;
+use Laravel\Telescope\Contracts\EntriesRepository;
+use Laravel\Telescope\EntryType;
+use Laravel\Telescope\IncomingEntry;
+use Laravel\Telescope\IncomingExceptionEntry;
+use Laravel\Telescope\Telescope;
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\CreatesApplication;
+
+class TelescopeServiceProviderTest extends BaseTestCase
+{
+    use CreatesApplication;
+
+    protected function tearDown(): void
+    {
+        $this->resetTelescopeState();
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function register_enables_telescope_dark_theme(): void
+    {
+        $this->registerTelescopeProvider();
+
+        $this->assertTrue(Telescope::$useDarkTheme);
+    }
+
+    #[Test]
+    public function hide_sensitive_request_details_in_non_local_environments(): void
+    {
+        $this->registerTelescopeProvider('production');
+
+        $this->assertContains('_token', Telescope::$hiddenRequestParameters);
+        $this->assertContains('cookie', Telescope::$hiddenRequestHeaders);
+        $this->assertContains('x-csrf-token', Telescope::$hiddenRequestHeaders);
+        $this->assertContains('x-xsrf-token', Telescope::$hiddenRequestHeaders);
+    }
+
+    #[Test]
+    public function hide_sensitive_request_details_skipped_in_local_environment(): void
+    {
+        $this->registerTelescopeProvider('local');
+
+        $this->assertNotContains('_token', Telescope::$hiddenRequestParameters);
+        $this->assertNotContains('cookie', Telescope::$hiddenRequestHeaders);
+    }
+
+    #[Test]
+    public function local_environment_records_all_entries(): void
+    {
+        $this->registerTelescopeProvider('local');
+
+        $entry = IncomingEntry::make([])->type(EntryType::REQUEST);
+
+        $this->assertTrue($this->shouldRecordEntry($entry));
+    }
+
+    #[Test]
+    public function production_environment_rejects_successful_requests(): void
+    {
+        $this->registerTelescopeProvider('production');
+
+        $entry = IncomingEntry::make(['response_status' => 200])->type(EntryType::REQUEST);
+
+        $this->assertFalse($this->shouldRecordEntry($entry));
+    }
+
+    #[Test]
+    public function production_environment_records_failed_requests(): void
+    {
+        $this->registerTelescopeProvider('production');
+
+        $entry = IncomingEntry::make(['response_status' => 500])->type(EntryType::REQUEST);
+
+        $this->assertTrue($this->shouldRecordEntry($entry));
+    }
+
+    #[Test]
+    public function production_environment_records_failed_jobs(): void
+    {
+        $this->registerTelescopeProvider('production');
+
+        $entry = IncomingEntry::make(['status' => 'failed'])->type(EntryType::JOB);
+
+        $this->assertTrue($this->shouldRecordEntry($entry));
+    }
+
+    #[Test]
+    public function production_environment_records_scheduled_tasks(): void
+    {
+        $this->registerTelescopeProvider('production');
+
+        $entry = IncomingEntry::make([])->type(EntryType::SCHEDULED_TASK);
+
+        $this->assertTrue($this->shouldRecordEntry($entry));
+    }
+
+    #[Test]
+    public function production_environment_records_reportable_exceptions(): void
+    {
+        $handler = $this->createMock(ExceptionHandler::class);
+        $handler->method('shouldReport')->willReturn(true);
+        $this->instance(ExceptionHandler::class, $handler);
+
+        $this->registerTelescopeProvider('production');
+
+        $entry = new IncomingExceptionEntry(
+            new \RuntimeException('report me'),
+            ['file' => '/tmp/example.php', 'line' => 1],
+        );
+
+        $this->assertTrue($this->shouldRecordEntry($entry));
+    }
+
+    #[Test]
+    public function production_environment_records_entries_with_monitored_tags(): void
+    {
+        $repository = $this->createMock(EntriesRepository::class);
+        $repository->method('isMonitoring')->with(['monitored'])->willReturn(true);
+        $this->instance(EntriesRepository::class, $repository);
+
+        $this->registerTelescopeProvider('production');
+
+        $entry = IncomingEntry::make([])->type(EntryType::QUERY)->tags(['monitored']);
+
+        $this->assertTrue($this->shouldRecordEntry($entry));
+    }
+
+    #[Test]
+    public function view_telescope_gate_allows_owner_email(): void
+    {
+        $this->registerTelescopeProvider('production');
+
+        $user = User::factory()->make(['email' => 'erik@erikgratz.com']);
+
+        $this->assertTrue(Gate::forUser($user)->allows('viewTelescope'));
+    }
+
+    #[Test]
+    public function view_telescope_gate_denies_other_users(): void
+    {
+        $this->registerTelescopeProvider('production');
+
+        $user = User::factory()->make(['email' => 'other@example.com']);
+
+        $this->assertFalse(Gate::forUser($user)->allows('viewTelescope'));
+    }
+
+    private function registerTelescopeProvider(string $environment = 'testing'): void
+    {
+        $this->setApplicationEnvironment($environment);
+
+        $this->resetTelescopeState();
+
+        $provider = new TelescopeServiceProvider($this->app);
+        $provider->register();
+        $provider->boot();
+    }
+
+    private function setApplicationEnvironment(string $environment): void
+    {
+        config(['app.env' => $environment]);
+        $this->app['env'] = $environment;
+    }
+
+    private function resetTelescopeState(): void
+    {
+        Telescope::$filterUsing = [];
+        Telescope::$useDarkTheme = false;
+        Telescope::$hiddenRequestHeaders = [
+            'authorization',
+            'php-auth-pw',
+        ];
+        Telescope::$hiddenRequestParameters = [
+            'password',
+            'password_confirmation',
+        ];
+    }
+
+    private function shouldRecordEntry(IncomingEntry $entry): bool
+    {
+        $this->assertNotEmpty(Telescope::$filterUsing);
+
+        foreach (Telescope::$filterUsing as $filter) {
+            if (! $filter($entry)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- Cap Horizon production workers with `HORIZON_MAX_PROCESSES` (default 4) instead of a fixed 10.
- Stop Telescope from recording every HTTP request in production; keep exceptions, failed requests/jobs, scheduled tasks, and monitored tags.
- Add Forge-oriented deploy snippets for PHP-FPM (`pm.max_requests`, `request_terminate_timeout`, sizing notes) and nginx (`limit_req` plus 444 for `.env`, WordPress paths, and non-`index.php` PHP probes).

## Test plan
- [ ] Set `HORIZON_MAX_PROCESSES=4` in production `.env` and run `php artisan horizon:terminate`
- [ ] Apply `deploy/php-fpm-www.pool.snippet` values in Forge PHP-FPM settings and reload `php8.4-fpm`
- [ ] Install `deploy/nginx/rate-limit-http.conf` on the server and merge `deploy/nginx/site-snippet.conf` into the site nginx config; `nginx -t` then reload
- [ ] Verify `curl -I https://erikgratz.com/.env` and `curl -I https://erikgratz.com/foo.php` are dropped before PHP
- [ ] Confirm legitimate site and Filament admin still work under normal traffic

Made with [Cursor](https://cursor.com)