### PR TITLE
Production hardening, Docker optimizations, and CardWidget math expressions

### DIFF
--- a/app/Filament/Widgets/CardWidget.php
+++ b/app/Filament/Widgets/CardWidget.php
@@ -2,11 +2,12 @@
 
 namespace App\Filament\Widgets;
 
+use App\Models\Card;
+use App\Rules\ValidMathExpression;
+use App\Support\MathExpression;
+use Filament\Tables\Columns\Summarizers\Sum;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Columns\TextInputColumn;
-use App\Models\Card;
-use Filament\Tables;
-use Filament\Tables\Columns\Summarizers\Sum;
 use Filament\Tables\Table;
 use Filament\Widgets\TableWidget as BaseWidget;
 use Illuminate\Database\Eloquent\Model;
@@ -40,17 +41,11 @@ class CardWidget extends BaseWidget
 
                     }),
 
-                TextInputColumn::make('balance')
-                    ->rules(['numeric'])
-                    ->updateStateUsing(fn ($record, $state) => $record->update(['balance' => is_null($state) ? 0 : $state]))
+                $this->mathInputColumn('balance')
                     ->summarize(Sum::make()->money()->label('')),
-                TextInputColumn::make('pending')
-                    ->rules(['numeric'])
-                    ->updateStateUsing(fn ($record, $state) => $record->update(['pending' => is_null($state) ? 0 : $state]))
+                $this->mathInputColumn('pending')
                     ->summarize(Sum::make()->money()->label('')),
-                TextInputColumn::make('interest_saving_balance')
-                    ->rules(['numeric'])
-                    ->updateStateUsing(fn ($record, $state) => $record->update(['interest_saving_balance' => is_null($state) ? 0 : $state]))
+                $this->mathInputColumn('interest_saving_balance')
                     ->label('ISB')
                     ->summarize([
                         Sum::make()->money()->label('Total'),
@@ -58,16 +53,25 @@ class CardWidget extends BaseWidget
                             ->query(fn (Builder $query) => $query->where('due_date', '>=', now()->day))
                             ->money()->label('Unpaid'),
                     ]),
-                TextInputColumn::make('interest_free_balance')
+                $this->mathInputColumn('interest_free_balance')
                     ->label('0% Bal')
-                    ->rules(['numeric'])
-                    ->updateStateUsing(fn ($record, $state) => $record->update(['interest_free_balance' => is_null($state) ? 0 : $state]))
                     ->summarize(Sum::make()->money()->label('')),
-                TextInputColumn::make('points_balance')
-                    ->rules(['numeric'])
-                    ->updateStateUsing(fn ($record, $state) => $record->update(['points_balance' => is_null($state) ? 0 : $state]))
+                $this->mathInputColumn('points_balance', asInteger: true)
                     ->label('Pts Bal')
                     ->summarize(Sum::make()->numeric()->label('')),
             ]);
+    }
+
+    private function mathInputColumn(string $field, bool $asInteger = false): TextInputColumn
+    {
+        return TextInputColumn::make($field)
+            ->rules([new ValidMathExpression])
+            ->updateStateUsing(function ($record, $state) use ($field, $asInteger) {
+                $resolved = MathExpression::resolve($state);
+                $value = $asInteger ? (int) round($resolved) : $resolved;
+                $record->update([$field => $value]);
+
+                return $value;
+            });
     }
 }

--- a/app/Rules/ValidMathExpression.php
+++ b/app/Rules/ValidMathExpression.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Rules;
+
+use App\Support\MathExpression;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use InvalidArgumentException;
+
+class ValidMathExpression implements ValidationRule
+{
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        try {
+            MathExpression::resolve($value);
+        } catch (InvalidArgumentException) {
+            $fail('The :attribute must be a valid number or math expression.');
+        }
+    }
+}

--- a/app/Support/MathExpression.php
+++ b/app/Support/MathExpression.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace App\Support;
+
+use InvalidArgumentException;
+
+class MathExpression
+{
+    private int $pos = 0;
+
+    public static function resolve(string|int|float|null $value): float
+    {
+        if ($value === null || (is_string($value) && trim($value) === '')) {
+            return 0.0;
+        }
+
+        if (is_int($value) || is_float($value)) {
+            return (float) $value;
+        }
+
+        $expression = trim((string) $value);
+
+        if (! preg_match('/^[\d\s\.\+\-\*\/\(\)]+$/', $expression)) {
+            throw new InvalidArgumentException('Expression contains invalid characters.');
+        }
+
+        $parser = new self($expression);
+        $result = $parser->parseExpression();
+
+        $parser->skipWhitespace();
+        if ($parser->pos < strlen($expression)) {
+            throw new InvalidArgumentException('Invalid expression syntax.');
+        }
+
+        return $result;
+    }
+
+    private function __construct(private readonly string $input) {}
+
+    private function parseExpression(): float
+    {
+        $left = $this->parseTerm();
+
+        while (true) {
+            $this->skipWhitespace();
+
+            if ($this->pos >= strlen($this->input)) {
+                break;
+            }
+
+            $char = $this->input[$this->pos];
+
+            if ($char === '+') {
+                $this->pos++;
+                $left += $this->parseTerm();
+            } elseif ($char === '-') {
+                $this->pos++;
+                $left -= $this->parseTerm();
+            } else {
+                break;
+            }
+        }
+
+        return $left;
+    }
+
+    private function parseTerm(): float
+    {
+        $left = $this->parseFactor();
+
+        while (true) {
+            $this->skipWhitespace();
+
+            if ($this->pos >= strlen($this->input)) {
+                break;
+            }
+
+            $char = $this->input[$this->pos];
+
+            if ($char === '*') {
+                $this->pos++;
+                $left *= $this->parseFactor();
+            } elseif ($char === '/') {
+                $this->pos++;
+                $right = $this->parseFactor();
+
+                if ($right == 0.0) {
+                    throw new InvalidArgumentException('Division by zero.');
+                }
+
+                $left /= $right;
+            } else {
+                break;
+            }
+        }
+
+        return $left;
+    }
+
+    private function parseFactor(): float
+    {
+        $this->skipWhitespace();
+
+        if ($this->pos >= strlen($this->input)) {
+            throw new InvalidArgumentException('Unexpected end of expression.');
+        }
+
+        $char = $this->input[$this->pos];
+
+        if ($char === '+' || $char === '-') {
+            $this->pos++;
+
+            $value = $this->parseFactor();
+
+            return $char === '-' ? -$value : $value;
+        }
+
+        if ($char === '(') {
+            $this->pos++;
+            $value = $this->parseExpression();
+            $this->skipWhitespace();
+
+            if ($this->pos >= strlen($this->input) || $this->input[$this->pos] !== ')') {
+                throw new InvalidArgumentException('Missing closing parenthesis.');
+            }
+
+            $this->pos++;
+
+            return $value;
+        }
+
+        return $this->parseNumber();
+    }
+
+    private function parseNumber(): float
+    {
+        $this->skipWhitespace();
+        $start = $this->pos;
+
+        while ($this->pos < strlen($this->input) && (ctype_digit($this->input[$this->pos]) || $this->input[$this->pos] === '.')) {
+            $this->pos++;
+        }
+
+        if ($start === $this->pos) {
+            throw new InvalidArgumentException('Expected number.');
+        }
+
+        $number = substr($this->input, $start, $this->pos - $start);
+
+        if (! is_numeric($number)) {
+            throw new InvalidArgumentException('Invalid number format.');
+        }
+
+        return (float) $number;
+    }
+
+    private function skipWhitespace(): void
+    {
+        while ($this->pos < strlen($this->input) && ctype_space($this->input[$this->pos])) {
+            $this->pos++;
+        }
+    }
+}

--- a/tests/Feature/Filament/CardWidgetTest.php
+++ b/tests/Feature/Filament/CardWidgetTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\Widgets\CardWidget;
+use App\Models\Card;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class CardWidgetTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->actingAs(User::factory()->create());
+    }
+
+    #[Test]
+    public function it_saves_resolved_decimal_expression_for_balance(): void
+    {
+        $card = Card::factory()->create(['balance' => 1500]);
+
+        Livewire::test(CardWidget::class)
+            ->call('updateTableColumnState', 'balance', (string) $card->getKey(), '1500 - 200');
+
+        $this->assertSame(1300.0, (float) $card->fresh()->balance);
+    }
+
+    #[Test]
+    public function it_saves_normalized_integer_expression_for_points_balance(): void
+    {
+        $card = Card::factory()->create(['points_balance' => 10000]);
+
+        Livewire::test(CardWidget::class)
+            ->call('updateTableColumnState', 'points_balance', (string) $card->getKey(), '10000 + 2500.6');
+
+        $this->assertSame(12501, $card->fresh()->points_balance);
+    }
+
+    #[Test]
+    public function it_rejects_invalid_expression_without_updating_balance(): void
+    {
+        $card = Card::factory()->create(['balance' => 1500]);
+
+        $response = Livewire::test(CardWidget::class)
+            ->call('updateTableColumnState', 'balance', (string) $card->getKey(), '1500 - abc');
+
+        $response->assertReturned(fn (mixed $returned): bool => is_array($returned)
+            && array_key_exists('error', $returned)
+            && str_contains($returned['error'], 'valid number or math expression'));
+        $this->assertSame(1500.0, (float) $card->fresh()->balance);
+    }
+}

--- a/tests/Unit/Support/MathExpressionTest.php
+++ b/tests/Unit/Support/MathExpressionTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Unit\Support;
+
+use App\Support\MathExpression;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class MathExpressionTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('validExpressionProvider')]
+    public function it_resolves_valid_expressions(mixed $input, float $expected): void
+    {
+        $this->assertSame($expected, MathExpression::resolve($input));
+    }
+
+    public static function validExpressionProvider(): array
+    {
+        return [
+            'null' => [null, 0.0],
+            'empty string' => ['', 0.0],
+            'whitespace only' => ['   ', 0.0],
+            'integer input' => [1500, 1500.0],
+            'float input' => [12.5, 12.5],
+            'plain numeric string' => ['1500', 1500.0],
+            'decimal string' => ['1500.50', 1500.5],
+            'addition and subtraction' => ['1500 - 200', 1300.0],
+            'addition' => ['100 + 50', 150.0],
+            'multiplication' => ['10 * 5', 50.0],
+            'division' => ['100 / 4', 25.0],
+            'operator precedence' => ['2 + 3 * 4', 14.0],
+            'parentheses' => ['(100 + 50) / 2', 75.0],
+            'whitespace tolerance' => ['1500 - 200', 1300.0],
+            'unary minus' => ['-200', -200.0],
+            'unary plus' => ['+200', 200.0],
+            'complex expression' => ['(1500 - 200) * 2', 2600.0],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('invalidExpressionProvider')]
+    public function it_rejects_invalid_expressions(mixed $input): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        MathExpression::resolve($input);
+    }
+
+    public static function invalidExpressionProvider(): array
+    {
+        return [
+            'invalid characters' => ['1500 - abc'],
+            'missing operand' => ['1500 -'],
+            'unbalanced parentheses' => ['(1500 - 200'],
+            'empty parentheses' => ['()'],
+            'division by zero' => ['100 / 0'],
+            'unsupported operator' => ['1500 ^ 200'],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- Reduce production memory pressure on small Forge servers by capping Horizon workers, tightening Telescope recording in production, and adding deploy snippets for PHP-FPM and nginx tuning.
- Improve local/CI Docker setup with PHP 8.4/8.5 images, testing database helpers, and CI workflow updates.
- Remove the Inertia/Vue frontend surface in favor of Livewire/Volt/Blade pages and auth flows, with updated route and test coverage.
- Allow basic math expressions in the Filament CardWidget inline numeric fields, resolving input like `1500 - 200` before save.

## Test plan
- [ ] Run `./vendor/bin/sail test`
- [ ] Verify production deploy snippets in `deploy/` are applied as expected on Forge
- [ ] Confirm public pages, auth flows, and Filament admin still load after the Inertia removal
- [ ] In the dashboard Cards widget, enter `1500 - 200` in a balance field and confirm it saves as `1300`
- [ ] Enter an invalid expression (e.g. `1500 - abc`) and confirm validation rejects it without updating the record


Made with [Cursor](https://cursor.com)