### PR TITLE
Allow math expressions in AccountWidget balance fields

### DIFF
--- a/app/Filament/Widgets/AccountWidget.php
+++ b/app/Filament/Widgets/AccountWidget.php
@@ -2,18 +2,19 @@
 
 namespace App\Filament\Widgets;
 
-use Filament\Tables\Columns\Layout\Stack;
-use Filament\Tables\Columns\TextColumn;
-use Filament\Tables\Columns\TextInputColumn;
+use App\Filament\Widgets\Concerns\HasMathInputColumn;
 use App\Models\Account;
-use Filament\Tables;
+use Filament\Tables\Columns\Layout\Stack;
 use Filament\Tables\Columns\Summarizers\Sum;
+use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Filament\Widgets\TableWidget as BaseWidget;
 use Illuminate\Database\Eloquent\Model;
 
 class AccountWidget extends BaseWidget
 {
+    use HasMathInputColumn;
+
     protected int|string|array $columnSpan = 'full';
 
     protected static ?string $heading = 'Accounts';
@@ -27,10 +28,8 @@ class AccountWidget extends BaseWidget
                     TextColumn::make('name')
                         ->description(fn (Model $record) => $record->updated_at->shortRelativeDiffForHumans(),
                             'below'),
-                    TextInputColumn::make('balance')
-                        ->rules(['numeric'])
+                    $this->mathInputColumn('balance')
                         ->summarize(Sum::make()->money()->label('')),
-                    //                        ->sortable()
                 ]),
             ])->contentGrid(fn () => $this->gridSize());
     }

--- a/app/Filament/Widgets/CardWidget.php
+++ b/app/Filament/Widgets/CardWidget.php
@@ -2,12 +2,10 @@
 
 namespace App\Filament\Widgets;
 
+use App\Filament\Widgets\Concerns\HasMathInputColumn;
 use App\Models\Card;
-use App\Rules\ValidMathExpression;
-use App\Support\MathExpression;
 use Filament\Tables\Columns\Summarizers\Sum;
 use Filament\Tables\Columns\TextColumn;
-use Filament\Tables\Columns\TextInputColumn;
 use Filament\Tables\Table;
 use Filament\Widgets\TableWidget as BaseWidget;
 use Illuminate\Database\Eloquent\Model;
@@ -15,6 +13,8 @@ use Illuminate\Database\Query\Builder;
 
 class CardWidget extends BaseWidget
 {
+    use HasMathInputColumn;
+
     protected int|string|array $columnSpan = 'full';
 
     protected static ?string $heading = 'Cards';
@@ -60,18 +60,5 @@ class CardWidget extends BaseWidget
                     ->label('Pts Bal')
                     ->summarize(Sum::make()->numeric()->label('')),
             ]);
-    }
-
-    private function mathInputColumn(string $field, bool $asInteger = false): TextInputColumn
-    {
-        return TextInputColumn::make($field)
-            ->rules([new ValidMathExpression])
-            ->updateStateUsing(function ($record, $state) use ($field, $asInteger) {
-                $resolved = MathExpression::resolve($state);
-                $value = $asInteger ? (int) round($resolved) : $resolved;
-                $record->update([$field => $value]);
-
-                return $value;
-            });
     }
 }

--- a/app/Filament/Widgets/Concerns/HasMathInputColumn.php
+++ b/app/Filament/Widgets/Concerns/HasMathInputColumn.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Filament\Widgets\Concerns;
+
+use App\Rules\ValidMathExpression;
+use App\Support\MathExpression;
+use Filament\Tables\Columns\TextInputColumn;
+
+trait HasMathInputColumn
+{
+    private function mathInputColumn(string $field, bool $asInteger = false): TextInputColumn
+    {
+        return TextInputColumn::make($field)
+            ->rules([new ValidMathExpression])
+            ->updateStateUsing(function ($record, $state) use ($field, $asInteger) {
+                $resolved = MathExpression::resolve($state);
+                $value = $asInteger ? (int) round($resolved) : $resolved;
+                $record->update([$field => $value]);
+
+                return $value;
+            });
+    }
+}

--- a/tests/Feature/Filament/AccountWidgetTest.php
+++ b/tests/Feature/Filament/AccountWidgetTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\Widgets\AccountWidget;
+use App\Models\Account;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class AccountWidgetTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->actingAs(User::factory()->create());
+    }
+
+    #[Test]
+    public function it_saves_resolved_decimal_expression_for_balance(): void
+    {
+        $account = Account::factory()->create(['balance' => 1500]);
+
+        Livewire::test(AccountWidget::class)
+            ->call('updateTableColumnState', 'balance', (string) $account->getKey(), '1500 - 200');
+
+        $this->assertSame(1300.0, (float) $account->fresh()->balance);
+    }
+
+    #[Test]
+    public function it_rejects_invalid_expression_without_updating_balance(): void
+    {
+        $account = Account::factory()->create(['balance' => 1500]);
+
+        $response = Livewire::test(AccountWidget::class)
+            ->call('updateTableColumnState', 'balance', (string) $account->getKey(), '1500 - abc');
+
+        $response->assertReturned(fn (mixed $returned): bool => is_array($returned)
+            && array_key_exists('error', $returned)
+            && str_contains($returned['error'], 'valid number or math expression'));
+        $this->assertSame(1500.0, (float) $account->fresh()->balance);
+    }
+}


### PR DESCRIPTION
## Summary
- Apply the same math expression support from the Card dashboard widget to the Accounts widget `balance` field.
- Extract shared `HasMathInputColumn` logic so both widgets validate, resolve, and persist computed values consistently.

## Test plan
- [ ] Run `./vendor/bin/sail test --filter='AccountWidget|CardWidget|MathExpression'`
- [ ] In the dashboard Accounts widget, enter `1500 - 200` in a balance field and confirm it saves as `1300`
- [ ] Enter an invalid expression (e.g. `1500 - abc`) and confirm validation rejects it without updating the record


Made with [Cursor](https://cursor.com)