### PR TITLE
Production hardening and dashboard stats overhaul

### DIFF
--- a/app/Filament/Resources/CardResource/Widgets/SpentPayingSaving.php
+++ b/app/Filament/Resources/CardResource/Widgets/SpentPayingSaving.php
@@ -14,8 +14,6 @@ use App\Models\StateDump;
 use App\Models\User;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 
@@ -240,13 +238,5 @@ class SpentPayingSaving extends BaseWidget
             return [$netWorthChart, $cardBalanceChart, $cardPendingChart, $cashPositionChart, $pointsChart];
         });
 
-    }
-
-    private static function sumTheStuff(Builder|Model $query): int|float
-    {
-        return $query->sum('balance')
-            + $query->sum('pending')
-            - $query->sum('interest_free_balance')
-            + $query->sum('interest_free_balance_payment');
     }
 }

--- a/app/Filament/Resources/CardResource/Widgets/SpentPayingSaving.php
+++ b/app/Filament/Resources/CardResource/Widgets/SpentPayingSaving.php
@@ -16,10 +16,16 @@ use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 
 class SpentPayingSaving extends BaseWidget
 {
+    /**
+     * @var int | array<string, ?int> | null
+     */
+    protected int | array | null $columns = ['@xl' => 4, '!@lg' => 4];
+
     protected function getStats(): array
     {
         $thisMonthName = now()->format('M');
@@ -32,29 +38,71 @@ class SpentPayingSaving extends BaseWidget
             $totalPoints,
             $pointsChart,
             $netWorth,
-            $netWorthChart
+            $netWorthChart,
         ] = self::getPointsAndChartData();
 
-        $rtn = [
+        $nextPotential = $moneyArray[$nextMonthName]['potential'];
+        $thirdPotential = $moneyArray[$thirdMonthName]['potential'];
+
+        return [
             Stat::make('Total Points', $totalPoints)
                 ->chart($pointsChart)
                 ->chartColor('danger'),
+            Stat::make($thisMonthName.' CC Due', '$'.$moneyArray[$thisMonthName]['spent']),
+            Stat::make($thisMonthName.' Potential Savings', '$'.$moneyArray[$thisMonthName]['potential']),
             Stat::make('Net Worth', '$'.$netWorth)
                 ->chart($netWorthChart)
                 ->chartColor('success'),
-            Stat::make($thisMonthName.' CC Due & Save',
-                '$'.$moneyArray[$thisMonthName]['spent']
-                .' / $'.$moneyArray[$thisMonthName]['potential']
-            ),
-        ];
 
-        foreach ([$nextMonthName, $thirdMonthName] as $month) {
-            $rtn[] = Stat::make($month.' CC Due', '$'.$moneyArray[$month]['spent']);
-            $rtn[] = Stat::make($month.' CC Unspent', '$'.$moneyArray[$month]['planned']);
-            $rtn[] = Stat::make($month.' Save', '$'.$moneyArray[$month]['potential']);
+            Stat::make($nextMonthName.' CC Due', '$'.$moneyArray[$nextMonthName]['spent']),
+            self::makeUnspentStat($nextMonthName, $moneyArray[$nextMonthName]),
+            Stat::make($nextMonthName.' CC Potential Save', '$'.$nextPotential),
+            Stat::make($nextMonthName.' CC Projected Net Worth', '$'.($netWorth + $nextPotential)),
+
+            Stat::make($thirdMonthName.' CC Due', '$'.$moneyArray[$thirdMonthName]['spent']),
+            self::makeUnspentStat($thirdMonthName, $moneyArray[$thirdMonthName]),
+            Stat::make($thirdMonthName.' CC Potential Save', '$'.$thirdPotential),
+            Stat::make($thirdMonthName.' CC Projected Net Worth', '$'.($netWorth + $nextPotential + $thirdPotential)),
+        ];
+    }
+
+    /**
+     * @param  array{spent: int|float, planned: int|float, potential: int|float, planned_items?: array<int, array{name: string, amount: float}>}  $monthData
+     */
+    protected static function makeUnspentStat(string $month, array $monthData): Stat
+    {
+        $stat = Stat::make($month.' CC Unspent', '$'.$monthData['planned']);
+
+        $items = $monthData['planned_items'] ?? [];
+
+        if ($monthData['planned'] != 0 || $items !== []) {
+            $stat->extraAttributes([
+                'title' => self::formatUnspentTooltip($items, (float) $monthData['planned']),
+            ]);
         }
 
-        return $rtn;
+        return $stat;
+    }
+
+    /**
+     * @param  array<int, array{name: string, amount: float}>  $items
+     */
+    public static function formatUnspentTooltip(array $items, float $total): string
+    {
+        if ($items === []) {
+            return $total == 0.0
+                ? 'No planned unpaid spends'
+                : 'Total: $'.number_format($total, 2);
+        }
+
+        $lines = array_map(
+            fn (array $item): string => $item['name'].' — $'.number_format($item['amount'], 2),
+            $items,
+        );
+
+        $lines[] = 'Total: $'.number_format($total, 2);
+
+        return implode("\n", $lines);
     }
 
     public static function getPointsAndChartData(): array
@@ -95,10 +143,12 @@ class SpentPayingSaving extends BaseWidget
         $planned = Payment::oneTimeUnpaidDueThisMonth()->pipe(new SumPayment);
         $planned += Payment::yearlyUnpaidDueThisMonth()->pipe(new SumPayment);
         $planned += Payment::monthlyUnpaid()->pipe(new SumPayment);
+        $nextPlannedItems = self::plannedItemsForNextMonth();
 
         $thirdPlanned = Payment::oneTimeUnpaidDueNextMonth()->pipe(new SumPayment);
         $thirdPlanned += Payment::yearlyDueNextMonth()->pipe(new SumPayment);
         $thirdPlanned += Payment::monthly()->pipe(new SumPayment);
+        $thirdPlannedItems = self::plannedItemsForThirdMonth();
 
         $thirdMonthSpent = Card::pastDue()->pipe(new SumCard)
             - $pastDueISB
@@ -109,20 +159,64 @@ class SpentPayingSaving extends BaseWidget
             $thisMonthName => [
                 'spent' => $thisMonthSpent + $loansDue,
                 'planned' => 0,
+                'planned_items' => [],
                 'potential' => $thisMonthCash - $thisMonthSpent - $loansDue,
             ],
             $nextMonthName => [
                 'spent' => $nextMonthSpent,
                 'planned' => $planned,
+                'planned_items' => $nextPlannedItems,
                 'potential' => $totalMonthIncome - $nextMonthSpent - $planned,
             ],
             $thirdMonthName => [
                 'spent' => $thirdMonthSpent,
                 'planned' => $thirdPlanned,
+                'planned_items' => $thirdPlannedItems,
                 'potential' => $totalMonthIncome - $thirdMonthSpent - $thirdPlanned,
             ],
-            // ...
         ];
+    }
+
+    /**
+     * @return array<int, array{name: string, amount: float}>
+     */
+    public static function plannedItemsForNextMonth(): array
+    {
+        return self::mapPaymentsToPlannedItems(
+            Payment::oneTimeUnpaidDueThisMonth()->with('spend')->get()
+                ->merge(Payment::yearlyUnpaidDueThisMonth()->with('spend')->get())
+                ->merge(Payment::monthlyUnpaid()->with('spend')->get())
+                ->unique('id')
+        );
+    }
+
+    /**
+     * @return array<int, array{name: string, amount: float}>
+     */
+    public static function plannedItemsForThirdMonth(): array
+    {
+        return self::mapPaymentsToPlannedItems(
+            Payment::oneTimeUnpaidDueNextMonth()->with('spend')->get()
+                ->merge(Payment::yearlyDueNextMonth()->with('spend')->get())
+                ->merge(Payment::monthly()->with('spend')->get())
+                ->unique('id')
+        );
+    }
+
+    /**
+     * @param  Collection<int, Payment>  $payments
+     * @return array<int, array{name: string, amount: float}>
+     */
+    protected static function mapPaymentsToPlannedItems(Collection $payments): array
+    {
+        return $payments
+            ->filter(fn (Payment $payment): bool => ! $payment->spend?->is_income)
+            ->map(fn (Payment $payment): array => [
+                'name' => $payment->spend?->name ?? 'Unknown',
+                'amount' => (float) $payment->amount,
+            ])
+            ->values()
+            ->all();
     }
 
     public static function getStateDumpCharts(): array

--- a/tests/Feature/Filament/SpentPayingSavingTest.php
+++ b/tests/Feature/Filament/SpentPayingSavingTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Tests\Feature\Filament;
+
+use App\Enums\Period;
+use App\Filament\Resources\CardResource\Widgets\SpentPayingSaving;
+use App\Models\Account;
+use App\Models\Card;
+use App\Models\Payment;
+use App\Models\PeriodicSpend;
+use App\Models\User;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+use Illuminate\Support\Carbon;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionMethod;
+use Tests\TestCase;
+
+class SpentPayingSavingTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function get_stats_returns_twelve_cards_in_expected_order(): void
+    {
+        Carbon::setTestNow('2026-05-15');
+
+        User::factory()->create(['email' => 'erik@erikgratz.com', 'monthly_pay' => 5000]);
+        Card::factory()->create();
+
+        $stats = $this->invokeGetStats();
+
+        $this->assertCount(12, $stats);
+
+        $labels = array_map(fn (Stat $stat): string => (string) $stat->getLabel(), $stats);
+
+        $this->assertSame([
+            'Total Points',
+            'May CC Due',
+            'May Potential Savings',
+            'Net Worth',
+            'Jun CC Due',
+            'Jun CC Unspent',
+            'Jun CC Potential Save',
+            'Jun CC Projected Net Worth',
+            'Jul CC Due',
+            'Jul CC Unspent',
+            'Jul CC Potential Save',
+            'Jul CC Projected Net Worth',
+        ], $labels);
+    }
+
+    #[Test]
+    public function widget_uses_four_column_layout(): void
+    {
+        $widget = new SpentPayingSaving;
+
+        $reflection = new ReflectionMethod($widget, 'getColumns');
+        $reflection->setAccessible(true);
+
+        $this->assertSame(['@xl' => 4, '!@lg' => 4], $reflection->invoke($widget));
+    }
+
+    #[Test]
+    public function unspent_stat_includes_tooltip_with_planned_spend_line_items(): void
+    {
+        Carbon::setTestNow('2026-05-15');
+
+        User::factory()->create(['email' => 'erik@erikgratz.com', 'monthly_pay' => 5000]);
+
+        $spend = PeriodicSpend::factory()->create([
+            'name' => 'Gym Membership',
+            'period' => Period::Monthly,
+            'is_income' => false,
+        ]);
+
+        Payment::factory()->create([
+            'spend_type' => getMorphAliasForClass(PeriodicSpend::class),
+            'spend_id' => $spend->id,
+            'amount' => 75,
+            'is_paid' => false,
+            'paid_on' => now()->setDay(20),
+        ]);
+
+        $money = SpentPayingSaving::getMoneyData();
+        $jun = now()->addMonth()->format('M');
+
+        $this->assertNotEmpty($money[$jun]['planned_items']);
+        $this->assertSame('Gym Membership', $money[$jun]['planned_items'][0]['name']);
+        $this->assertSame(75.0, $money[$jun]['planned_items'][0]['amount']);
+
+        $unspentStat = collect($this->invokeGetStats())
+            ->first(fn (Stat $stat): bool => (string) $stat->getLabel() === $jun.' CC Unspent');
+
+        $this->assertNotNull($unspentStat);
+
+        $extra = $unspentStat->getExtraAttributes();
+
+        $this->assertArrayHasKey('title', $extra);
+        $this->assertStringContainsString('Gym Membership', $extra['title']);
+        $this->assertStringContainsString('75.00', $extra['title']);
+    }
+
+    #[Test]
+    public function projected_net_worth_uses_cumulative_future_savings(): void
+    {
+        Carbon::setTestNow('2026-05-15');
+
+        User::factory()->create(['email' => 'erik@erikgratz.com', 'monthly_pay' => 8000]);
+
+        Account::factory()->create(['balance' => 10000]);
+        Card::factory()->create(['balance' => 2000, 'pending' => 500, 'points_balance' => 0]);
+
+        [, , $netWorth] = SpentPayingSaving::getPointsAndChartData();
+        $money = SpentPayingSaving::getMoneyData();
+
+        $jun = now()->addMonth()->format('M');
+        $jul = now()->addMonths(2)->format('M');
+
+        $stats = $this->invokeGetStats();
+        $valuesByLabel = [];
+        foreach ($stats as $stat) {
+            $valuesByLabel[(string) $stat->getLabel()] = (string) $stat->getValue();
+        }
+
+        $junPotential = $money[$jun]['potential'];
+        $julPotential = $money[$jul]['potential'];
+
+        $this->assertSame('$'.($netWorth + $junPotential), $valuesByLabel['Jun CC Projected Net Worth']);
+        $this->assertSame('$'.($netWorth + $junPotential + $julPotential), $valuesByLabel['Jul CC Projected Net Worth']);
+    }
+
+    /**
+     * @return array<Stat>
+     */
+    protected function invokeGetStats(): array
+    {
+        $widget = new SpentPayingSaving;
+
+        $method = new ReflectionMethod($widget, 'getStats');
+        $method->setAccessible(true);
+
+        return $method->invoke($widget);
+    }
+}

--- a/tests/Feature/Filament/SpentPayingSavingTest.php
+++ b/tests/Feature/Filament/SpentPayingSavingTest.php
@@ -2,15 +2,19 @@
 
 namespace Tests\Feature\Filament;
 
+use App\Enums\AccountType;
 use App\Enums\Period;
 use App\Filament\Resources\CardResource\Widgets\SpentPayingSaving;
 use App\Models\Account;
 use App\Models\Card;
 use App\Models\Payment;
 use App\Models\PeriodicSpend;
+use App\Models\Spend;
+use App\Models\StateDump;
 use App\Models\User;
 use Filament\Widgets\StatsOverviewWidget\Stat;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
 use PHPUnit\Framework\Attributes\Test;
 use ReflectionMethod;
 use Tests\TestCase;
@@ -20,6 +24,7 @@ class SpentPayingSavingTest extends TestCase
     protected function tearDown(): void
     {
         Carbon::setTestNow();
+        Cache::forget('stateDumps');
 
         parent::tearDown();
     }
@@ -29,7 +34,7 @@ class SpentPayingSavingTest extends TestCase
     {
         Carbon::setTestNow('2026-05-15');
 
-        User::factory()->create(['email' => 'erik@erikgratz.com', 'monthly_pay' => 5000]);
+        $this->ensureErikUser(['monthly_pay' => 5000]);
         Card::factory()->create();
 
         $stats = $this->invokeGetStats();
@@ -70,7 +75,7 @@ class SpentPayingSavingTest extends TestCase
     {
         Carbon::setTestNow('2026-05-15');
 
-        User::factory()->create(['email' => 'erik@erikgratz.com', 'monthly_pay' => 5000]);
+        $this->ensureErikUser(['monthly_pay' => 5000]);
 
         $spend = PeriodicSpend::factory()->create([
             'name' => 'Gym Membership',
@@ -110,9 +115,13 @@ class SpentPayingSavingTest extends TestCase
     {
         Carbon::setTestNow('2026-05-15');
 
-        User::factory()->create(['email' => 'erik@erikgratz.com', 'monthly_pay' => 8000]);
+        $erik = $this->ensureErikUser(['monthly_pay' => 8000]);
 
-        Account::factory()->create(['balance' => 10000]);
+        Account::factory()->create([
+            'user_id' => $erik->id,
+            'type' => AccountType::Checking,
+            'balance' => 10000,
+        ]);
         Card::factory()->create(['balance' => 2000, 'pending' => 500, 'points_balance' => 0]);
 
         [, , $netWorth] = SpentPayingSaving::getPointsAndChartData();
@@ -134,6 +143,122 @@ class SpentPayingSavingTest extends TestCase
         $this->assertSame('$'.($netWorth + $junPotential + $julPotential), $valuesByLabel['Jul CC Projected Net Worth']);
     }
 
+    #[Test]
+    public function get_money_data_applies_half_paycheck_before_the_fifteenth(): void
+    {
+        Carbon::setTestNow('2026-05-05');
+
+        $erik = $this->ensureErikUser(['monthly_pay' => 4000]);
+
+        Account::factory()->create([
+            'user_id' => $erik->id,
+            'type' => AccountType::Checking,
+            'balance' => 1000,
+        ]);
+
+        Card::factory()->create([
+            'due_date' => now()->addDays(5)->day,
+            'interest_saving_balance' => 0,
+            'balance' => 100,
+            'pending' => 0,
+            'interest_free_balance' => 0,
+            'interest_free_balance_payment' => 0,
+        ]);
+
+        $may = now()->format('M');
+        $money = SpentPayingSaving::getMoneyData();
+
+        $this->assertEqualsWithDelta(1000 + 2000 - 100, $money[$may]['potential'], 0.01);
+    }
+
+    #[Test]
+    public function planned_items_for_third_month_include_next_month_one_time_spend(): void
+    {
+        Carbon::setTestNow('2026-05-15');
+
+        $this->ensureErikUser();
+
+        $spend = Spend::factory()->bare()->create([
+            'name' => 'Annual Insurance',
+            'is_income' => false,
+        ]);
+
+        Payment::factory()->create([
+            'spend_type' => getMorphAliasForClass(Spend::class),
+            'spend_id' => $spend->id,
+            'amount' => 300,
+            'is_paid' => false,
+            'paid_on' => now()->addMonth()->startOfMonth()->addDays(3),
+        ]);
+
+        $items = SpentPayingSaving::plannedItemsForThirdMonth();
+
+        $this->assertCount(1, $items);
+        $this->assertSame('Annual Insurance', $items[0]['name']);
+        $this->assertSame(300.0, $items[0]['amount']);
+    }
+
+    #[Test]
+    public function get_state_dump_charts_returns_chart_arrays(): void
+    {
+        Carbon::setTestNow('2026-05-15');
+
+        $card = Card::factory()->create();
+        StateDump::factory()->create([
+            'data' => [
+                Card::class => [
+                    [
+                        'id' => $card->id,
+                        'balance' => 100,
+                        'pending' => 50,
+                        'points_balance' => 1000,
+                    ],
+                ],
+            ],
+        ]);
+
+        [$netWorthChart, $cardBalanceChart, $cardPendingChart, $cashPositionChart, $pointsChart] = SpentPayingSaving::getStateDumpCharts();
+
+        $this->assertIsArray($netWorthChart);
+        $this->assertIsArray($cardBalanceChart);
+        $this->assertIsArray($cardPendingChart);
+        $this->assertIsArray($cashPositionChart);
+        $this->assertIsArray($pointsChart);
+        $this->assertNotEmpty($pointsChart);
+        $this->assertSame($card->id, $card->fresh()->id);
+    }
+
+    #[Test]
+    public function make_unspent_stat_omits_tooltip_when_no_planned_items(): void
+    {
+        $stat = $this->invokeMakeUnspentStat('Jun', [
+            'planned' => 0,
+            'planned_items' => [],
+        ]);
+
+        $this->assertSame('Jun CC Unspent', (string) $stat->getLabel());
+        $this->assertSame('$0', (string) $stat->getValue());
+        $this->assertSame([], $stat->getExtraAttributes());
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    protected function ensureErikUser(array $attributes = []): User
+    {
+        $user = User::whereEmail('erik@erikgratz.com')->first();
+
+        if ($user) {
+            $user->update($attributes);
+
+            return $user->fresh();
+        }
+
+        return User::factory()->create(array_merge([
+            'email' => 'erik@erikgratz.com',
+        ], $attributes));
+    }
+
     /**
      * @return array<Stat>
      */
@@ -145,5 +270,16 @@ class SpentPayingSavingTest extends TestCase
         $method->setAccessible(true);
 
         return $method->invoke($widget);
+    }
+
+    /**
+     * @param  array{planned: int|float, planned_items?: array<int, array{name: string, amount: float}>}  $monthData
+     */
+    protected function invokeMakeUnspentStat(string $month, array $monthData): Stat
+    {
+        $method = new ReflectionMethod(SpentPayingSaving::class, 'makeUnspentStat');
+        $method->setAccessible(true);
+
+        return $method->invoke(null, $month, $monthData);
     }
 }

--- a/tests/Feature/Filament/WidgetsTest.php
+++ b/tests/Feature/Filament/WidgetsTest.php
@@ -2,14 +2,13 @@
 
 namespace Tests\Feature\Filament;
 
-use App\Filament\Resources\CardResource\Widgets\SpentPayingSaving;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class WidgetsTest extends TestCase
 {
     #[Test]
-    public function it_exists()
+    public function it_exists(): void
     {
         $this->assertTrue(true);
     }

--- a/tests/Unit/Filament/SpentPayingSavingTooltipTest.php
+++ b/tests/Unit/Filament/SpentPayingSavingTooltipTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Unit\Filament;
+
+use App\Filament\Resources\CardResource\Widgets\SpentPayingSaving;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class SpentPayingSavingTooltipTest extends TestCase
+{
+    #[Test]
+    public function format_unspent_tooltip_lists_items_and_total(): void
+    {
+        $tooltip = SpentPayingSaving::formatUnspentTooltip([
+            ['name' => 'Rent', 'amount' => 1200.5],
+            ['name' => 'Internet', 'amount' => 80],
+        ], 1280.5);
+
+        $this->assertStringContainsString('Rent — $1,200.50', $tooltip);
+        $this->assertStringContainsString('Internet — $80.00', $tooltip);
+        $this->assertStringContainsString('Total: $1,280.50', $tooltip);
+    }
+
+    #[Test]
+    public function format_unspent_tooltip_handles_empty_items(): void
+    {
+        $this->assertSame(
+            'No planned unpaid spends',
+            SpentPayingSaving::formatUnspentTooltip([], 0),
+        );
+    }
+}

--- a/tests/Unit/Filament/SpentPayingSavingTooltipTest.php
+++ b/tests/Unit/Filament/SpentPayingSavingTooltipTest.php
@@ -29,4 +29,13 @@ class SpentPayingSavingTooltipTest extends TestCase
             SpentPayingSaving::formatUnspentTooltip([], 0),
         );
     }
+
+    #[Test]
+    public function format_unspent_tooltip_shows_total_when_items_missing_but_total_present(): void
+    {
+        $this->assertSame(
+            'Total: $42.00',
+            SpentPayingSaving::formatUnspentTooltip([], 42),
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Hardens production and CI: Docker/PHP-FPM tuning, nginx rate limits, reduced memory pressure, and Telescope filtering in production.
- Replaces the Inertia/Vue public surface with Livewire/Blade pages and updates auth flows, routes, and related tests.
- Adds math-expression inline editing for Filament card/account balance fields.
- Expands the dashboard `SpentPayingSaving` widget to a 3x4 layout with CC Unspent hover tooltips and cumulative projected net-worth cards.

## Test plan
- [ ] Run `php artisan test` (MySQL/Sail) including new Filament and provider tests
- [ ] Verify Filament dashboard: 12 stats in 3x4 order; hover CC Unspent shows planned spend line items
- [ ] Confirm card/account widget inline math updates save correctly
- [ ] Smoke-test public pages (home, contact, portfolio, play) and auth (login, reset password, verify email)
- [ ] Confirm admin panel and Horizon still load in staging/production-like config


Made with [Cursor](https://cursor.com)