### PR TITLE
Align CC unspent tooltip rows with planned totals

### DIFF
--- a/app/Filament/Resources/CardResource/Widgets/SpentPayingSaving.php
+++ b/app/Filament/Resources/CardResource/Widgets/SpentPayingSaving.php
@@ -9,7 +9,6 @@ use App\Models\Collections\StateDumpCollection as SDC;
 use App\Models\LoanAgainstSavings;
 use App\Models\Payment;
 use App\Models\Scopes\SumCard;
-use App\Models\Scopes\SumPayment;
 use App\Models\StateDump;
 use App\Models\User;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
@@ -138,15 +137,13 @@ class SpentPayingSaving extends BaseWidget
 //            - Card::futureDue()->noISBYet()->sum('interest_saving_balance')
             - $thisMonthSpent;
 
-        $planned = Payment::oneTimeUnpaidDueThisMonth()->pipe(new SumPayment);
-        $planned += Payment::yearlyUnpaidDueThisMonth()->pipe(new SumPayment);
-        $planned += Payment::monthlyUnpaid()->pipe(new SumPayment);
-        $nextPlannedItems = self::plannedItemsForNextMonth();
+        $nextPlannedSummary = self::summarizePlannedPayments(self::plannedPaymentsForNextMonth());
+        $planned = $nextPlannedSummary['total'];
+        $nextPlannedItems = $nextPlannedSummary['items'];
 
-        $thirdPlanned = Payment::oneTimeUnpaidDueNextMonth()->pipe(new SumPayment);
-        $thirdPlanned += Payment::yearlyDueNextMonth()->pipe(new SumPayment);
-        $thirdPlanned += Payment::monthly()->pipe(new SumPayment);
-        $thirdPlannedItems = self::plannedItemsForThirdMonth();
+        $thirdPlannedSummary = self::summarizePlannedPayments(self::plannedPaymentsForThirdMonth());
+        $thirdPlanned = $thirdPlannedSummary['total'];
+        $thirdPlannedItems = $thirdPlannedSummary['items'];
 
         $thirdMonthSpent = Card::pastDue()->pipe(new SumCard)
             - $pastDueISB
@@ -176,45 +173,55 @@ class SpentPayingSaving extends BaseWidget
     }
 
     /**
-     * @return array<int, array{name: string, amount: float}>
+     * @return Collection<int, Payment>
      */
-    public static function plannedItemsForNextMonth(): array
+    protected static function plannedPaymentsForNextMonth(): Collection
     {
-        return self::mapPaymentsToPlannedItems(
-            Payment::oneTimeUnpaidDueThisMonth()->with('spend')->get()
-                ->merge(Payment::yearlyUnpaidDueThisMonth()->with('spend')->get())
-                ->merge(Payment::monthlyUnpaid()->with('spend')->get())
-                ->unique('id')
-        );
+        return Payment::oneTimeUnpaidDueThisMonth()->with('spend')->get()
+            ->merge(Payment::yearlyUnpaidDueThisMonth()->with('spend')->get())
+            ->merge(Payment::monthlyUnpaid()->with('spend')->get())
+            ->unique('id')
+            ->values();
     }
 
     /**
-     * @return array<int, array{name: string, amount: float}>
+     * @return Collection<int, Payment>
      */
-    public static function plannedItemsForThirdMonth(): array
+    protected static function plannedPaymentsForThirdMonth(): Collection
     {
-        return self::mapPaymentsToPlannedItems(
-            Payment::oneTimeUnpaidDueNextMonth()->with('spend')->get()
-                ->merge(Payment::yearlyDueNextMonth()->with('spend')->get())
-                ->merge(Payment::monthly()->with('spend')->get())
-                ->unique('id')
-        );
+        return Payment::oneTimeUnpaidDueNextMonth()->with('spend')->get()
+            ->merge(Payment::yearlyDueNextMonth()->with('spend')->get())
+            ->merge(Payment::monthly()->with('spend')->get())
+            ->unique('id')
+            ->values();
     }
 
     /**
      * @param  Collection<int, Payment>  $payments
-     * @return array<int, array{name: string, amount: float}>
+     * @return array{total: float, items: array<int, array{name: string, amount: float}>}
      */
-    protected static function mapPaymentsToPlannedItems(Collection $payments): array
+    protected static function summarizePlannedPayments(Collection $payments): array
     {
-        return $payments
-            ->filter(fn (Payment $payment): bool => ! $payment->spend?->is_income)
-            ->map(fn (Payment $payment): array => [
+        $items = $payments
+            ->filter(fn (Payment $payment): bool => (bool) $payment->spend)
+            ->map(function (Payment $payment): array {
+                $amount = (float) $payment->amount;
+                if ($payment->spend?->is_income) {
+                    $amount *= -1;
+                }
+
+                return [
                 'name' => $payment->spend?->name ?? 'Unknown',
-                'amount' => (float) $payment->amount,
-            ])
+                'amount' => $amount,
+                ];
+            })
             ->values()
             ->all();
+
+        return [
+            'total' => (float) array_sum(array_column($items, 'amount')),
+            'items' => $items,
+        ];
     }
 
     public static function getStateDumpCharts(): array

--- a/tests/Feature/Filament/SpentPayingSavingTest.php
+++ b/tests/Feature/Filament/SpentPayingSavingTest.php
@@ -191,11 +191,62 @@ class SpentPayingSavingTest extends TestCase
             'paid_on' => now()->addMonth()->startOfMonth()->addDays(3),
         ]);
 
-        $items = SpentPayingSaving::plannedItemsForThirdMonth();
+        $money = SpentPayingSaving::getMoneyData();
+        $items = $money[now()->addMonths(2)->format('M')]['planned_items'];
 
         $this->assertCount(1, $items);
         $this->assertSame('Annual Insurance', $items[0]['name']);
         $this->assertSame(300.0, $items[0]['amount']);
+    }
+
+    #[Test]
+    public function planned_total_and_tooltip_items_include_income_offsets_consistently(): void
+    {
+        Carbon::setTestNow('2026-05-15');
+
+        $this->ensureErikUser();
+
+        $expense = PeriodicSpend::factory()->create([
+            'name' => 'Expense',
+            'period' => Period::Monthly,
+            'is_income' => false,
+        ]);
+        $income = PeriodicSpend::factory()->create([
+            'name' => 'Income',
+            'period' => Period::Monthly,
+            'is_income' => true,
+        ]);
+
+        Payment::factory()->create([
+            'spend_type' => getMorphAliasForClass(PeriodicSpend::class),
+            'spend_id' => $expense->id,
+            'amount' => 100,
+            'is_paid' => false,
+            'paid_on' => now()->setDay(20),
+        ]);
+        Payment::factory()->create([
+            'spend_type' => getMorphAliasForClass(PeriodicSpend::class),
+            'spend_id' => $income->id,
+            'amount' => 40,
+            'is_paid' => false,
+            'paid_on' => now()->setDay(21),
+        ]);
+
+        $money = SpentPayingSaving::getMoneyData();
+        $jun = now()->addMonth()->format('M');
+
+        $this->assertSame(60.0, $money[$jun]['planned']);
+        $this->assertCount(2, $money[$jun]['planned_items']);
+        $this->assertSame('Expense', $money[$jun]['planned_items'][0]['name']);
+        $this->assertSame(100.0, $money[$jun]['planned_items'][0]['amount']);
+        $this->assertSame('Income', $money[$jun]['planned_items'][1]['name']);
+        $this->assertSame(-40.0, $money[$jun]['planned_items'][1]['amount']);
+
+        $stat = $this->invokeMakeUnspentStat($jun, $money[$jun]);
+        $tooltip = (string) ($stat->getExtraAttributes()['title'] ?? '');
+
+        $this->assertStringContainsString('Income — $-40.00', $tooltip);
+        $this->assertStringContainsString('Total: $60.00', $tooltip);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- Build `CC Unspent` tooltip rows from the exact same payment collections used to compute month `planned` totals in `SpentPayingSaving::getMoneyData()`.
- Include income spends as negative entries in tooltip rows so the tooltip net always matches the displayed planned total.
- Remove now-unused `SumPayment` path and old helper methods, and add regression coverage for income-offset consistency.

## Test plan
- [x] `docker compose exec -T laravel.test php artisan test --filter=SpentPayingSaving`
- [ ] Verify in dashboard UI that `CC Unspent` tooltip itemization matches the stat total for mixed income/expense planned spends


Made with [Cursor](https://cursor.com)