### PR TITLE
Add foreign currency payments with USD settlement on paid date

### DIFF
--- a/app/Filament/Resources/CardResource/Widgets/SpentPayingSaving.php
+++ b/app/Filament/Resources/CardResource/Widgets/SpentPayingSaving.php
@@ -205,7 +205,7 @@ class SpentPayingSaving extends BaseWidget
         $items = $payments
             ->filter(fn (Payment $payment): bool => (bool) $payment->spend)
             ->map(function (Payment $payment): array {
-                $amount = (float) $payment->amount;
+                $amount = $payment->amountInUsd();
                 if ($payment->spend?->is_income) {
                     $amount *= -1;
                 }

--- a/app/Filament/Resources/SpendResource.php
+++ b/app/Filament/Resources/SpendResource.php
@@ -77,22 +77,9 @@ class SpendResource extends Resource
                 Toggle::make('is_income'),
             ])->columnSpanFull(),
 //            Grid::make(1)->schema([
-                Repeater::make('payments')
+                Spend::paymentFilamentFormComponent()
                     ->columnSpanFull()
-                    ->relationship()
-                    ->grid(['xs' => 1, 'md' => 2])
-                    ->schema([
-                        TextInput::make('amount')
-                            ->prefix('$')
-                            ->numeric()
-                            ->required(),
-                        Toggle::make('is_paid'),
-                        DatePicker::make('paid_on')->nullable(),
-                        Select::make('card_id')
-                            ->label('Card')
-                            ->options(Card::all()->pluck('name', 'id'))
-                            ->nullable(),
-                    ])->defaultItems(0)->addActionLabel('Add Payment'),
+                    ->grid(['xs' => 1, 'md' => 2]),
 //            ]),
         ];
     }

--- a/app/Jobs/DailyUpkeep.php
+++ b/app/Jobs/DailyUpkeep.php
@@ -21,9 +21,10 @@ class DailyUpkeep implements ShouldQueue
      */
     public function handle()
     {
-        Payment::where('paid_on', '=', now()->toDateString())
-            ->whereIsPaid(false)
-            ->update(['is_paid' => true]);
+        Payment::query()
+            ->where('paid_on', '=', now()->toDateString())
+            ->where('is_paid', false)
+            ->each(fn (Payment $payment) => $payment->update(['is_paid' => true]));
 
         Artisan::call('fx:refresh');
 

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -2,25 +2,38 @@
 
 namespace App\Models;
 
+use App\Enums\CurrencyCode;
 use App\Enums\Period;
 use App\Models\Traits\GetsDumped;
+use App\Services\Currency\ExchangeRateService;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Support\Carbon;
 
 class Payment extends Model
 {
     use GetsDumped, HasFactory;
 
-    protected $fillable = ['spend_id', 'spend_type', 'amount', 'is_paid', 'paid_on', 'card_id'];
+    protected $fillable = ['spend_id', 'spend_type', 'amount', 'currency', 'is_paid', 'paid_on', 'card_id'];
 
-    public function casts()
+    protected function casts(): array
     {
         return [
             'paid_on' => 'date',
             'is_paid' => 'boolean',
+            'currency' => CurrencyCode::class,
         ];
+    }
+
+    protected static function booted(): void
+    {
+        static::saved(function (Payment $payment): void {
+            if ($payment->shouldSettleToUsd()) {
+                $payment->settleToUsd();
+            }
+        });
     }
 
     public function spend(): MorphTo
@@ -31,6 +44,55 @@ class Payment extends Model
     public function card(): BelongsTo
     {
         return $this->belongsTo(Card::class);
+    }
+
+    /**
+     * USD amount for dashboards and aggregates. Paid foreign payments are stored in USD after settlement.
+     * Unpaid foreign payments use the latest available rate.
+     */
+    public function amountInUsd(): float
+    {
+        $amount = (float) $this->amount;
+
+        if ($this->currency->isUsd()) {
+            return round($amount, 2);
+        }
+
+        if ($this->is_paid) {
+            return round($amount, 2);
+        }
+
+        return app(ExchangeRateService::class)->convertToUsd($amount, $this->currency);
+    }
+
+    public function shouldSettleToUsd(): bool
+    {
+        if ($this->currency->isUsd() || ! $this->is_paid) {
+            return false;
+        }
+
+        return $this->wasRecentlyCreated
+            || $this->wasChanged('is_paid')
+            || ($this->wasChanged('paid_on') && $this->is_paid);
+    }
+
+    public function settleToUsd(): void
+    {
+        if ($this->currency->isUsd()) {
+            return;
+        }
+
+        $settlementDate = $this->paid_on ?? now();
+        $usdAmount = app(ExchangeRateService::class)->convertToUsd(
+            (float) $this->amount,
+            $this->currency,
+            Carbon::parse($settlementDate),
+        );
+
+        $this->updateQuietly([
+            'amount' => $usdAmount,
+            'currency' => CurrencyCode::USD,
+        ]);
     }
 
     public function scopeOneTimeDueThisMonth($query)
@@ -109,6 +171,4 @@ class Payment extends Model
             ->whereMorphRelation('spend', PeriodicSpend::class, 'period', '=', Period::Yearly)
             ->whereMonth('paid_on', '=', now()->month);
     }
-
-
 }

--- a/app/Models/Traits/HasPayments.php
+++ b/app/Models/Traits/HasPayments.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\Traits;
 
+use App\Enums\CurrencyCode;
 use App\Models\Card;
 use App\Models\Payment;
 use Filament\Forms\Components\DatePicker;
@@ -28,7 +29,10 @@ trait HasPayments
     public function amount(): Attribute
     {
         return Attribute::make(
-            get: fn () => $this->payments()->sum('amount')
+            get: fn () => round(
+                $this->payments->sum(fn (Payment $payment): float => $payment->amountInUsd()),
+                2,
+            ),
         );
     }
 
@@ -38,8 +42,13 @@ trait HasPayments
             ->columns(4)
             ->relationship()
             ->schema([
+                Select::make('currency')
+                    ->options(CurrencyCode::options())
+                    ->default(CurrencyCode::USD->value)
+                    ->required()
+                    ->live(),
                 TextInput::make('amount')
-                    ->prefix('$')
+                    ->prefix(fn ($get): string => (string) ($get('currency') ?? CurrencyCode::USD->value))
                     ->numeric()
                     ->required(),
                 Toggle::make('is_paid'),

--- a/app/Services/Currency/ExchangeRateApiProvider.php
+++ b/app/Services/Currency/ExchangeRateApiProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Currency;
 
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Http;
 
 class ExchangeRateApiProvider implements ExchangeRateProvider
@@ -12,7 +13,7 @@ class ExchangeRateApiProvider implements ExchangeRateProvider
      * @param  list<string>  $currencies
      * @return array<string, float>
      */
-    public function fetchToUsdMultipliers(array $currencies): array
+    public function fetchToUsdMultipliers(array $currencies, ?Carbon $date = null): array
     {
         if ($currencies === []) {
             return [];

--- a/app/Services/Currency/ExchangeRateProvider.php
+++ b/app/Services/Currency/ExchangeRateProvider.php
@@ -10,5 +10,5 @@ interface ExchangeRateProvider
      * @param  list<string>  $currencies  ISO 4217 codes excluding USD
      * @return array<string, float> currency code => multiply native balance by this for USD
      */
-    public function fetchToUsdMultipliers(array $currencies): array;
+    public function fetchToUsdMultipliers(array $currencies, ?\Carbon\Carbon $date = null): array;
 }

--- a/app/Services/Currency/ExchangeRateService.php
+++ b/app/Services/Currency/ExchangeRateService.php
@@ -28,16 +28,16 @@ class ExchangeRateService
         $rates = $this->getCachedRates($dateKey);
 
         if (! array_key_exists($currency->value, $rates)) {
-            $this->refreshRatesForAccounts();
+            $this->ensureRatesForDate($dateKey, [$currency->value]);
             $rates = $this->getCachedRates($dateKey);
         }
 
         return $rates[$currency->value] ?? 1.0;
     }
 
-    public function convertToUsd(float $amount, CurrencyCode $currency): float
+    public function convertToUsd(float $amount, CurrencyCode $currency, ?Carbon $date = null): float
     {
-        return round($amount * $this->getToUsdMultiplier($currency), 2);
+        return round($amount * $this->getToUsdMultiplier($currency, $date), 2);
     }
 
     /**
@@ -73,7 +73,7 @@ class ExchangeRateService
         $multipliers = ['USD' => 1.0];
 
         if ($nonUsd !== []) {
-            $fetched = $this->fetchMultipliersWithFailover($nonUsd);
+            $fetched = $this->fetchMultipliersWithFailover($nonUsd, now());
             $multipliers = array_merge($multipliers, $fetched);
         }
 
@@ -118,24 +118,55 @@ class ExchangeRateService
     }
 
     /**
+     * @param  list<string>  $currencyCodes
+     */
+    public function ensureRatesForDate(string $dateKey, array $currencyCodes): void
+    {
+        $nonUsd = array_values(array_filter(
+            $currencyCodes,
+            fn (string $code): bool => strtoupper($code) !== 'USD',
+        ));
+
+        if ($nonUsd === []) {
+            return;
+        }
+
+        $cached = $this->getCachedRates($dateKey);
+        $missing = array_values(array_filter(
+            $nonUsd,
+            fn (string $code): bool => ! array_key_exists($code, $cached),
+        ));
+
+        if ($missing === []) {
+            return;
+        }
+
+        $date = Carbon::parse($dateKey);
+        $fetched = $this->fetchMultipliersWithFailover($missing, $date);
+        $this->putCachedRates($dateKey, array_merge(['USD' => 1.0], $cached, $fetched));
+    }
+
+    /**
      * @param  list<string>  $currencies
      * @return array<string, float>
      */
-    protected function fetchMultipliersWithFailover(array $currencies): array
+    protected function fetchMultipliersWithFailover(array $currencies, Carbon $date): array
     {
         try {
-            return $this->frankfurter->fetchToUsdMultipliers($currencies);
+            return $this->frankfurter->fetchToUsdMultipliers($currencies, $date);
         } catch (\Throwable $e) {
             Log::warning('Frankfurter exchange rate fetch failed, trying ExchangeRate-API.', [
                 'message' => $e->getMessage(),
+                'date' => $date->toDateString(),
             ]);
         }
 
         try {
-            return $this->exchangeRateApi->fetchToUsdMultipliers($currencies);
+            return $this->exchangeRateApi->fetchToUsdMultipliers($currencies, $date);
         } catch (\Throwable $e) {
             Log::error('Exchange rate fetch failed for all providers.', [
                 'currencies' => $currencies,
+                'date' => $date->toDateString(),
                 'message' => $e->getMessage(),
             ]);
 
@@ -156,7 +187,10 @@ class ExchangeRateService
      */
     protected function putCachedRates(string $dateKey, array $multipliers): void
     {
-        Cache::put($this->cacheKey($dateKey), $multipliers, now()->endOfDay());
+        $date = Carbon::parse($dateKey);
+        $ttl = $date->isToday() ? now()->endOfDay() : now()->addYear();
+
+        Cache::put($this->cacheKey($dateKey), $multipliers, $ttl);
     }
 
     protected function cacheKey(string $dateKey): string

--- a/app/Services/Currency/FrankfurterExchangeRateProvider.php
+++ b/app/Services/Currency/FrankfurterExchangeRateProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Currency;
 
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Http;
 
 class FrankfurterExchangeRateProvider implements ExchangeRateProvider
@@ -12,7 +13,7 @@ class FrankfurterExchangeRateProvider implements ExchangeRateProvider
      * @param  list<string>  $currencies
      * @return array<string, float>
      */
-    public function fetchToUsdMultipliers(array $currencies): array
+    public function fetchToUsdMultipliers(array $currencies, ?Carbon $date = null): array
     {
         if ($currencies === []) {
             return [];
@@ -20,8 +21,11 @@ class FrankfurterExchangeRateProvider implements ExchangeRateProvider
 
         $symbols = implode(',', $currencies);
         $baseUrl = rtrim(config('currency.frankfurter.base_url'), '/');
+        $endpoint = $date !== null
+            ? "{$baseUrl}/{$date->toDateString()}"
+            : "{$baseUrl}/latest";
 
-        $response = Http::timeout(15)->get("{$baseUrl}/latest", [
+        $response = Http::timeout(15)->get($endpoint, [
             'from' => 'USD',
             'to' => $symbols,
         ]);

--- a/database/factories/PaymentFactory.php
+++ b/database/factories/PaymentFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enums\CurrencyCode;
 use App\Models\Card;
 use App\Models\Payment;
 use App\Models\PeriodicSpend;
@@ -18,6 +19,7 @@ class PaymentFactory extends Factory
     {
         return [
             'amount' => rand(10, 4000),
+            'currency' => CurrencyCode::USD,
             'is_paid' => $this->faker->boolean(),
             'paid_on' => Carbon::now(),
             'spend_type' => self::spendType(),

--- a/database/migrations/2026_05_25_000001_add_currency_to_payments_table.php
+++ b/database/migrations/2026_05_25_000001_add_currency_to_payments_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('payments', function (Blueprint $table) {
+            $table->string('currency', 3)->default('USD')->after('amount');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('payments', function (Blueprint $table) {
+            $table->dropColumn('currency');
+        });
+    }
+};

--- a/tests/Feature/Models/PaymentCurrencySettlementTest.php
+++ b/tests/Feature/Models/PaymentCurrencySettlementTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tests\Feature\Models;
+
+use App\Enums\CurrencyCode;
+use App\Models\Payment;
+use App\Models\Spend;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class PaymentCurrencySettlementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function marking_foreign_payment_paid_converts_amount_using_paid_on_date_rate(): void
+    {
+        Http::fake([
+            'api.frankfurter.dev/v1/2024-06-01*' => Http::response([
+                'amount' => 1,
+                'base' => 'USD',
+                'date' => '2024-06-01',
+                'rates' => ['CAD' => 1.25],
+            ]),
+        ]);
+
+        $payment = Payment::factory()->create([
+            'spend_type' => getMorphAliasForClass(Spend::class),
+            'spend_id' => Spend::factory()->bare()->noPayments()->create()->id,
+            'currency' => CurrencyCode::CAD,
+            'amount' => 125,
+            'is_paid' => false,
+            'paid_on' => '2024-06-01',
+        ]);
+
+        $payment->update(['is_paid' => true]);
+
+        $payment->refresh();
+
+        $this->assertSame(CurrencyCode::USD, $payment->currency);
+        $this->assertEqualsWithDelta(100.0, (float) $payment->amount, 0.01);
+    }
+
+    #[Test]
+    public function payments_due_today_settle_when_marked_paid_like_daily_upkeep(): void
+    {
+        Carbon::setTestNow('2024-06-01');
+
+        Http::fake([
+            'api.frankfurter.dev/v1/2024-06-01*' => Http::response([
+                'amount' => 1,
+                'base' => 'USD',
+                'date' => '2024-06-01',
+                'rates' => ['EUR' => 0.8],
+            ]),
+        ]);
+
+        $payment = Payment::factory()->create([
+            'spend_type' => getMorphAliasForClass(Spend::class),
+            'spend_id' => Spend::factory()->bare()->noPayments()->create()->id,
+            'currency' => CurrencyCode::EUR,
+            'amount' => 80,
+            'is_paid' => false,
+            'paid_on' => '2024-06-01',
+        ]);
+
+        Payment::query()
+            ->where('paid_on', '=', now()->toDateString())
+            ->where('is_paid', false)
+            ->each(fn (Payment $due) => $due->update(['is_paid' => true]));
+
+        $payment->refresh();
+
+        $this->assertTrue($payment->is_paid);
+        $this->assertSame(CurrencyCode::USD, $payment->currency);
+        $this->assertEqualsWithDelta(100.0, (float) $payment->amount, 0.01);
+    }
+
+    #[Test]
+    public function unpaid_foreign_payment_amount_in_usd_uses_latest_rate(): void
+    {
+        Http::fake([
+            'api.frankfurter.dev/*' => Http::response([
+                'amount' => 1,
+                'base' => 'USD',
+                'date' => now()->toDateString(),
+                'rates' => ['CAD' => 1.25],
+            ]),
+        ]);
+
+        $payment = Payment::factory()->create([
+            'spend_type' => getMorphAliasForClass(Spend::class),
+            'spend_id' => Spend::factory()->bare()->noPayments()->create()->id,
+            'currency' => CurrencyCode::CAD,
+            'amount' => 125,
+            'is_paid' => false,
+        ]);
+
+        app(\App\Services\Currency\ExchangeRateService::class)->ensureRatesForDate(
+            now()->toDateString(),
+            ['CAD'],
+        );
+
+        $this->assertEqualsWithDelta(100.0, $payment->amountInUsd(), 0.01);
+    }
+}


### PR DESCRIPTION
Payments can be recorded in any supported currency. When marked paid
or when paid_on arrives, amounts convert to USD using Frankfurter rates
for that date (with failover), rounded to two decimals.

Co-authored-by: Cursor <cursoragent@cursor.com>
